### PR TITLE
Prevent using Yoda-style conditionals

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -53,6 +53,10 @@ services:
     PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer: ~
     PhpCsFixer\Fixer\ControlStructure\SwitchCaseSemicolonToColonFixer: ~
     PhpCsFixer\Fixer\ControlStructure\SwitchCaseSpaceFixer: ~
+    PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer:
+        equal: false
+        identical: false
+        less_and_greater: false
     PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer: ~

--- a/tests/Sample.php
+++ b/tests/Sample.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\CodingStandard;
 
-class Sample
+final class Sample
 {
     public function foo(): void
     {
+        $bar = null;
+
+        if ($bar === null) {
+            return;
+        }
     }
 }

--- a/tests/SampleSpec.php
+++ b/tests/SampleSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\CodingStandard;
 
-class SampleSpec
+final class SampleSpec
 {
     function foo(): void
     {


### PR DESCRIPTION
It's hard to see the benefit for Yoda-style conditionals in a codebase using `===` instead of `=`. Instead, it makes code look like `if (0 < $value)`, which is read like `if zero is less than the value`.