### PR TITLE
Add PhpCsFixer\Fixer\Casing\LowercaseStaticReferenceFixer fixer

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -19,8 +19,9 @@ services:
     PhpCsFixer\Fixer\Basic\NonPrintableCharacterFixer: ~
     PhpCsFixer\Fixer\Casing\LowercaseConstantsFixer: ~
     PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer: ~
-    PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~
+    PhpCsFixer\Fixer\Casing\LowercaseStaticReferenceFixer: ~
     PhpCsFixer\Fixer\Casing\MagicConstantCasingFixer: ~
+    PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer: ~
     PhpCsFixer\Fixer\CastNotation\CastSpacesFixer: ~
     PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer: ~
     PhpCsFixer\Fixer\CastNotation\ModernizeTypesCastingFixer: ~


### PR DESCRIPTION
Eg. this changes `STATIC::method()` to `static::method()`.