### PR TITLE
Add PhpCsFixer\Fixer\ConstantNotation\NativeConstantInvocationFixer fixer

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -53,6 +53,7 @@ services:
     PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer: ~
     PhpCsFixer\Fixer\ControlStructure\SwitchCaseSemicolonToColonFixer: ~
     PhpCsFixer\Fixer\ControlStructure\SwitchCaseSpaceFixer: ~
+    PhpCsFixer\Fixer\ConstantNotation\NativeConstantInvocationFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer: ~
     PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer: ~


### PR DESCRIPTION
Eg. this changes `DIRECTORY_SEPARATOR` to `\DIRECTORY_SEPARATOR`.