### PR TITLE
Add check for const visibility

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -37,7 +37,8 @@ services:
     PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer: ~
     PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer: ~
     PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer: ~
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer: ~
+    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
+        elements: [const, property, method]
     PhpCsFixer\Fixer\Comment\HashToSlashCommentFixer: ~
     PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer: ~
     PhpCsFixer\Fixer\Comment\NoTrailingWhitespaceInCommentFixer: ~

--- a/tests/Sample.php
+++ b/tests/Sample.php
@@ -6,6 +6,8 @@ namespace Tests\CodingStandard;
 
 class Sample
 {
+    public const BAR = 'bar';
+
     public function foo(): void
     {
     }


### PR DESCRIPTION
By default, we are checking only methods and arguments. Eg: `const BAR` -> `public const BAR`