### PR TITLE
Replaced deprecated NoExtraConsecutiveBlankLinesFixer

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -124,19 +124,20 @@ services:
     PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer: ~
     PhpCsFixer\Fixer\Whitespace\IndentationTypeFixer: ~
     PhpCsFixer\Fixer\Whitespace\LineEndingFixer: ~
-    PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer:
-        - 'break'
-        - 'case'
-        - 'continue'
-        - 'curly_brace_block'
-        - 'default'
-        - 'extra'
-        - 'parenthesis_brace_block'
-        - 'return'
-        - 'square_brace_block'
-        - 'switch'
-        - 'throw'
-        - 'use'
+    PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer:
+        tokens:
+            - 'break'
+            - 'case'
+            - 'continue'
+            - 'curly_brace_block'
+            - 'default'
+            - 'extra'
+            - 'parenthesis_brace_block'
+            - 'return'
+            - 'square_brace_block'
+            - 'switch'
+            - 'throw'
+            - 'use'
     PhpCsFixer\Fixer\Whitespace\NoSpacesAroundOffsetFixer: ~
     PhpCsFixer\Fixer\Whitespace\NoSpacesInsideParenthesisFixer: ~
     PhpCsFixer\Fixer\Whitespace\NoTrailingWhitespaceFixer: ~


### PR DESCRIPTION
After an update of Ecs to 5.4.0, the configuration of `NoExtraConsecutiveBlankLinesFixer` seems incorrect. This fixer is just a proxy to `NoExtraBlankLinesFixer`.
I just replaced the fixer.