### PR TITLE
Added ClassAttributesSeparationFixer

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -27,6 +27,7 @@ services:
     PhpCsFixer\Fixer\CastNotation\ModernizeTypesCastingFixer: ~
     PhpCsFixer\Fixer\CastNotation\NoShortBoolCastFixer: ~
     PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer: ~
+    PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer: ~
     PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer:
         singleItemSingleLine: true
         multiLineExtendsEachSingleLine: true


### PR DESCRIPTION
This will add blank lines between class attributes. I.e. something like this:

```
/** @var int */
private $id;
/** @var string */
private $val;
```

will be converted into:

```
/** @var int */
private $id;

/** @var string */
private $val;
```