### PR TITLE
Allow mixed in docblocks

### DIFF
--- a/easy-coding-standard.yml
+++ b/easy-coding-standard.yml
@@ -94,7 +94,8 @@ services:
     PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer: ~
     PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer: ~
-    PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer: ~
+    PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer:
+        allow_mixed: true
     PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagFixer: ~
     PhpCsFixer\Fixer\Phpdoc\PhpdocNoAccessFixer: ~


### PR DESCRIPTION
It'll allow us to keep docblocks like this:

```php
/**
 * @param mixed data
 *
 * @return mixed
 */
function foo($data) {
  return $data;
}
```

Psalm requires on those docblocks while checking the codebase.