### PR TITLE
Update composer.json with newest easy coding standard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
 
 env:
-    - ECS_VERSION="^6.0"
     - ECS_VERSION="^7.0"
+    - ECS_VERSION="^8.0"
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.1",
 
         "friendsofphp/php-cs-fixer": "^2.12",
-        "symplify/easy-coding-standard": "^6.0.1||^7.0"
+        "symplify/easy-coding-standard": "^7.0 || ^8.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
-
-        "friendsofphp/php-cs-fixer": "^2.12",
-        "symplify/easy-coding-standard": "^7.0 || ^8.0"
+        "symplify/easy-coding-standard": "^7.3 || ^8.1"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,9 @@
             "Tests\\SyliusLabs\\CodingStandard\\": "tests/"
         }
     },
-    "conflict": {
-        "symplify/package-builder": "^7.2",
-        "symplify/smart-file-system": "^7.2"
-    },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.1-dev"
+            "dev-master": "3.2-dev"
         }
     }
 }


### PR DESCRIPTION
This lib is a dev dependency and as such there's no reason to support lower versions of packages.

As an argument for this I have problems with dev dependencies when I run CI tests and use the `--prefer-lowest --prefer-stable` composer flags to test my 'real' dependencies in lower versions. Sometimes my dev deps will make build errors because something changed. In the case with coding standard it's very common to have something to do with the release of a new php version, in this case php 7.4 and especially typed properties.