### PR TITLE
Add slevomat/coding-standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.1",
+        "slevomat/coding-standard": "^6.3",
         "symplify/easy-coding-standard": "^7.3 || ^8.1"
     },
     "autoload-dev": {


### PR DESCRIPTION
It was removed in symplify/easy-coding-standard v8.1.20, but Sylius' coding standard uses it