### PR TITLE
Add conflict to symplify/package-builder ^8.3 and allow for ECS ^8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 env:
     - ECS_VERSION="^9.0"
-    - ECS_VERSION="^8.3"
+    - ECS_VERSION="^8.0"
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "slevomat/coding-standard": "^6.3",
-        "symplify/easy-coding-standard": "^8.3 || ^9.0"
+        "symplify/easy-coding-standard": "^8.0 || ^9.0"
+    },
+    "conflict": {
+        "symplify/package-builder": "^8.3"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Prevents error like this one:
```
PHP Notice:  Undefined index: serviceKeywords in /home/runner/work/SyliusThemeBundle/SyliusThemeBundle/vendor/symplify/easy-coding-standard/src/Yaml/CheckerServiceParametersShifter.php on line 72
```