### PR TITLE
Remove duplicated ClassAttributesSeparationFixer and use default config

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -189,9 +189,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ClassDefinitionFixer::class)
         ->call('configure', [['single_item_single_line' => true, 'multi_line_extends_each_single_line' => true]]);
 
-    $services->set(ClassAttributesSeparationFixer::class)
-        ->call('configure', [['elements' => ['method']]]);
-
     $services->set(NoBlankLinesAfterClassOpeningFixer::class);
 
     $services->set(NoNullPropertyInitializationFixer::class);


### PR DESCRIPTION
Sorry but there was an error in the previous PR. The ClassAttributesSeparationFixer is specified twice and the [upgrade.md ](https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/UPGRADE-v3.md)file was misleading: `['elements' => ['method']]` is not a valid config for this fixer.
Btw the default config is ok https://cs.symfony.com/doc/rules/class_notation/class_attributes_separation.html so we can avoid to specify a custom configuration for this fixer.