### PR TITLE
Adjust config to avoid InvalidOptionsException about ClassAttributesSeparationFixer

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -190,7 +190,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('configure', [['single_item_single_line' => true, 'multi_line_extends_each_single_line' => true]]);
 
     $services->set(ClassAttributesSeparationFixer::class)
-        ->call('configure', [['elements' => ['method']]]);
+        ->call('configure', [['elements' => ['method' => ClassAttributesSeparationFixer::SPACING_ONE]]]);
 
     $services->set(NoBlankLinesAfterClassOpeningFixer::class);
 


### PR DESCRIPTION
Experiencing the same issue as in https://github.com/symplify/symplify/issues/3159, this adjustment makes it work again