### PR TITLE
Remove un-necessary ecs config

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -189,9 +189,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ClassDefinitionFixer::class)
         ->call('configure', [['single_item_single_line' => true, 'multi_line_extends_each_single_line' => true]]);
 
-    $services->set(ClassAttributesSeparationFixer::class)
-        ->call('configure', [['elements' => ['method']]]);
-
     $services->set(NoBlankLinesAfterClassOpeningFixer::class);
 
     $services->set(NoNullPropertyInitializationFixer::class);


### PR DESCRIPTION
First, line 187 does the same but in better due to default config.

Second, it seems to make ecs crash with this error: 

```
A script named run would override a Composer command and has been skipped
> check-style: ecs check
PHP Fatal error:  Uncaught ECSPrefix20210818\Symfony\Component\OptionsResolver\Exception\InvalidOptionsException: Unexpected element type, expected any of "const", "method", "property", "trait_import", got "integer#0". in /home/stephane/nvme/PhpstormProjects/Sylius/SyliusGiftCardPlugin/vendor/symplify/easy-coding-standard/vendor/friendsofphp/php-cs-fixer/src/Fixer/ClassNotation/ClassAttributesSeparationFixer.php:153
Stack trace:
#0 /Sylius/SyliusGiftCardPlugin/vendor/symplify/easy-coding-standard/vendor/friendsofphp/php-cs-fixer/src/FixerConfiguration/FixerConfigurationResolver.php(77): PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer::PhpCsFixer\Fixer\ClassNotation\{closure}()
#1 /Sylius/SyliusGiftCardPlugin/vendor/symplify/easy-coding-standard/vendor/symfony/options-resolver/OptionsResolver.php(932): PhpCsFixer\FixerConfiguration\FixerConfigurationResolver::PhpCsFixer\FixerConfiguration\{closure}()
#2 /Syl in /home/stephane/nvme/PhpstormProjects/Sylius/SyliusGiftCardPlugin/vendor/symplify/easy-coding-standard/vendor/friendsofphp/php-cs-fixer/src/AbstractFixer.php on line 120
Script ecs check handling the check-style event returned with error code 255
```

![image](https://user-images.githubusercontent.com/9363039/130088196-fdc47d97-4b8d-429b-be67-fcb06d870b51.png)
