### PR TITLE
Conflict against newer ECS 10.x releases due to exception causing hard fail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "symplify/easy-coding-standard": "^9.0 || ^10.0"
     },
     "conflict": {
+        "symplify/easy-coding-standard": ">=10.2.11",
         "symplify/package-builder": "^8.3"
     },
     "autoload-dev": {


### PR DESCRIPTION
In https://github.com/symplify/symplify/commit/9d1b0ea67bd15cdcbcf4177e76093c3d152f47f2 (released with 10.2.11), the warning message about the deprecated config syntax was changed from printing a warning to throwing an exception.  This effectively means that using ECS >=10.2.11,<11.0 with the `ContainerConfigurator` based configuration is impossible as the ECS application doesn't handle this exception which causes it to abort.  Since this package doesn't yet provide an `ECSConfig` based configuration, conflicting against newer 10.x releases is the only sane option until the newer syntax is supported.