### PR TITLE
Add conflict to ecs >=13.1.3

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -9,3 +9,12 @@ Incompatible with PHP_CodeSniffer 4.x due to a changed method signature in PHPCS
 ```
 Fatal error: Declaration of ... must be compatible with ...
 ```
+
+## `symplify/easy-coding-standard: >=13.1.3`
+
+[ECS 13.1.3](https://github.com/easy-coding-standard/ecs/releases/tag/13.1.3) introduced a BC break that affected all of our CIs. The release ships a bundled `friendsofphp/php-cs-fixer` with `PhpCsFixer\Console\Application` removed from the prefixed vendor tree, while `ConfigurableFixerTrait` still imports it. Configuring any fixer that has a deprecated option triggers the deprecation path and fails with:
+
+```
+PHP Fatal error: Uncaught Error: Class "PhpCsFixer\Console\Application" not found
+in vendor/symplify/easy-coding-standard/vendor/friendsofphp/php-cs-fixer/src/Fixer/ConfigurableFixerTrait.php
+```

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "conflict": {
         "slevomat/coding-standard": ">=8.23",
+        "symplify/easy-coding-standard": ">=13.1.3",
         "symplify/package-builder": "^8.3"
     },
     "autoload-dev": {


### PR DESCRIPTION
The https://github.com/easy-coding-standard/ecs/releases/tag/13.1.3 introduced a BC break, that affected all of our CI's